### PR TITLE
Update to Sucrase 3.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function sucrase(opts = {}) {
 		name: 'sucrase',
 
 		transform(code, id) {
-			return transform(code, {
+			const result = transform(code, {
 				transforms: opts.transforms,
 				jsxPragma: opts.jsxPragma,
 				jsxFragmentPragma: opts.jsxFragmentPragma,
@@ -16,8 +16,16 @@ module.exports = function sucrase(opts = {}) {
 					opts.enableLegacyTypeScriptModuleInterop,
 				enableLegacyBabel5ModuleInterop:
 					opts.enableLegacyTypeScriptModuleInterop,
-				filePath: opts.filePath,
+				production: opts.production,
+				filePath: id,
+				sourceMapOptions: {
+					compiledFilename: id,
+				}
 			});
+			return {
+				code: result.code,
+				map: result.sourceMap,
+			}
 		},
 	};
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "rollup-pluginutils": "^2.3.0",
-    "sucrase": "^2.2.0"
+    "sucrase": "^3.3.0"
   },
   "description": "Compile TypeScript, Flow, JSX etc with Sucrase",
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/mz@^0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/mz/-/mz-0.0.32.tgz#e8248b4e41424c052edc1725dd33650c313a3659"
-  dependencies:
-    "@types/node" "*"
-
-"@types/node@*":
-  version "10.1.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.3.tgz#5c16980936c4e3c83ce64e8ed71fb37bd7aea135"
-
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -274,16 +264,14 @@ rollup-pluginutils@^2.3.0:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
-sucrase@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-2.2.0.tgz#a860f428e3df57af3cdb490f065ff1360776b2d7"
+sucrase@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.3.0.tgz#d8c24726c27be599a34251163f14e545a1bb63df"
   dependencies:
-    "@types/mz" "^0.0.32"
     commander "^2.12.2"
     lines-and-columns "^1.1.6"
     mz "^2.7.0"
     pirates "^3.0.2"
-    tslib "^1.9.0"
 
 thenify-all@^1.0.0:
   version "1.6.0"
@@ -296,7 +284,3 @@ thenify-all@^1.0.0:
   resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
   dependencies:
     any-promise "^1.0.0"
-
-tslib@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.1.tgz#a5d1f0532a49221c87755cfcc89ca37197242ba7"


### PR DESCRIPTION
Sucrase has source maps now! (They're a bit boring, though, since they just map
each line to itself.) I mostly modeled the change off of rollup-plugin-babel,
and it seems to work and generate a sensible-looking source map.

Also udpate the options object:
* `filePath` should be specified per-file, not globally.
* We always want to generate source maps.
* There's a new `production` flag that we should forward.